### PR TITLE
Deprecate in favor of freshdesk-api (v2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,22 @@
 # node-freshdesk
 
+**WARNING**
+
+[![npm version](https://img.shields.io/badge/NPM-deprecated-red.svg)](https://github.com/maxkoryukov/node-freshdesk-api/issues/1)
+
+This repository and corresponding NPM package are deprecated in favor of [**freshdesk-api**](https://www.npmjs.com/package/freshdesk-api).
+
+Useful links:
+
+1. [NPM package](https://www.npmjs.com/package/freshdesk-api):
+    * v2 is **preferred**: `npm install freshdesk-api`
+    * v1: `npm install freshdesk-api@APIv1`
+2. GitHub, `node-freshdesk-api`:
+    * [v2 on master branch](https://github.com/arjunkomath/node-freshdesk-api)
+    * [v1 in additional branch](https://github.com/arjunkomath/node-freshdesk-api/tree/API-v1)
+
+----
+
 A NodeJS library for integrating your backend with Freshdesk.
 
 [![npm version](https://badge.fury.io/js/freshdesk.svg)](https://badge.fury.io/js/freshdesk)


### PR DESCRIPTION
Hello, I would like to offer you to take part in this open source, github-based freshdesk-project: https://github.com/arjunkomath/node-freshdesk-api . I'm sure, this project could be a good alternative for your project.
 
So, if you are not going to maintain **your** project in the future:

1. Merge this PR to your repository
1. Publish your old package on NPM (to publish the new `README.md` on NPM)
1. Deprecate your old NPM package, with this command:
    ```shell
    npm deprecate <YOUR-PACKAGE-NAME> "Please, use this package: freshdesk-api"
    ```
   Like this:
    ```shell
    npm deprecate node-freshdesk-myown "Please, use this package: freshdesk-api"
    ```

**Don't unpublish** your package, it is enough to deprecate it :+1: 

PS: this PR is a part of maxkoryukov/node-freshdesk-api#1